### PR TITLE
Process Chef::Node::ImmutableArray as an Array

### DIFF
--- a/templates/default/backupconfiguration.ini.erb
+++ b/templates/default/backupconfiguration.ini.erb
@@ -22,14 +22,14 @@ when = <%= @when_executed %>
 @options.each_pair do |key, value|
 
 	# A repetition of the same key
-	if value.class == Array 
+	if value.class <= Array 
 		value.each do |item| 
 %><%= 		"#{key} = #{item}" %>
 <%
 		end
 
 	# A Section
-	elsif value.class == Hash
+	elsif value.class <= Hash
 %>
 
 <%=   "[#{key}]" %>
@@ -37,7 +37,7 @@ when = <%= @when_executed %>
 		value.each_pair do |sub_key, sub_value|
 			unless sub_value.nil?
 				# (inside) A repetition of the same key
-				if sub_value.class == Array 
+				if sub_value.class <= Array 
 					sub_value.each do |item| 
 %><%=   				"#{sub_key} = #{item}" %>
 <%		


### PR DESCRIPTION
Hi,

When you define an array of values in attribute that attribute is created as `Chef::Node::ImmutableArray` but not as `Array`.
Hence the logic in template in backupninja resource fails and the array is not expanded.
This commit should fix this.

I've done the similar fix for Hash for the cases when you pass attribute as a whole parameter. Chef uses `Chef::Node::ImmutableMash` for that.

In case you are wondering what the `<=` operation means for classes it is checking if a class is a subclass of another class.
See http://stackoverflow.com/questions/4545518/test-whether-a-ruby-class-is-a-subclass-of-another-class for example.

Hope that makes sense.
